### PR TITLE
Add a utility to remove binstar project vars

### DIFF
--- a/remove_binstar_project_var.py
+++ b/remove_binstar_project_var.py
@@ -1,0 +1,36 @@
+# This removes the project variable "BINSTAR_TOKEN" as it somehow interferes
+# with the same-named variable from the group variables.
+
+import glob
+
+from conda_smithy.azure_ci_utils import build_client, get_default_build_definition
+from conda_smithy.azure_ci_utils import default_config as config
+from vsts.build.v4_1.models import BuildDefinitionVariable
+
+
+bclient = build_client()
+
+feedstocks = sorted(glob.glob('*-feedstock'))
+# feedstocks = ['databroker-pack-feedstock']
+
+for project in feedstocks:
+    print(f'Project name: {project}')
+    existing_definitions = bclient.get_definitions(
+        project=config.project_name, name=project
+    )
+    ed = existing_definitions[0]
+    ed = bclient.get_definition(ed.id, project=config.project_name)
+    variables = {}
+    build_definition = get_default_build_definition(
+        'nsls-ii-forge',
+        project,
+        config=config,
+        variables=variables,
+        id=ed.id,
+        revision=ed.revision,
+    )
+    bclient.update_definition(
+        definition=build_definition,
+        definition_id=ed.id,
+        project=ed.project.name,
+    )


### PR DESCRIPTION
I had to fight a bit with the duplicate tokens, as there were 2 tokens associated with the feedstocks after running the following:
```bash
$ for d in *-feedstock; do echo $d; conda-smithy update-anaconda-token --without-travis --without-circle --without-drone --without-appveyor --organization nsls-ii-forge --feedstock $d; echo -e "\n\n"; done
```
One token appeared to be in the list of the project-specific variables, and another one was integrated via Azure Pipelines' group variables.

A side problem I noticed was that this procedure took tokens from the `BINSTAR_TOKEN` environment variable as the first choice. I had to make it in sync with the one in `~/.conda-smithy/anaconda.token`.

This specific PR helps to remove the project-specific token from all feedstock configurations on Azure Pipelines.